### PR TITLE
Add option for remote branches

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,7 +1,15 @@
 use std::process::{Command, Stdio};
 
-pub fn get_branch_names() {
-	let branch_names: Option<String> = branch_names();
+pub enum BranchListings {
+	Local,
+	Remotes,
+}
+
+pub fn get_branch_names(bt: BranchListings) {
+	let branch_names: Option<String> = match bt {
+		BranchListings::Local => branch_names(),
+		BranchListings::Remotes => remote_branches(),
+	};
 	if !branch_names.is_none() {
 		let mut stripped_branch_names = branch_names.unwrap();
 		if stripped_branch_names.ends_with('\n') {
@@ -44,6 +52,24 @@ fn branch_names() -> Option<String> {
 	let mut cmd = Command::new("git");
 	cmd.arg("branch");
 	cmd.arg("--color");
+	let output = cmd
+		.stdout(Stdio::piped())
+		.output()
+		.expect("Failed to execute `git branch`");
+	
+	if output.status.success() {
+		let branch_names = String::from_utf8_lossy(&output.stdout).into_owned();
+		return Some(branch_names);
+	} else {
+		return None
+	}
+}
+
+fn remote_branches() -> Option<String> {
+	let mut cmd = Command::new("git");
+	cmd.arg("branch");
+	cmd.arg("--color");
+	cmd.arg("--remotes");
 	let output = cmd
 		.stdout(Stdio::piped())
 		.output()
@@ -104,3 +130,4 @@ pub fn current_branch_name() -> Option<String> {
 	}
 }
 */
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,16 @@ fn main() {
 								.short("B")
 								.long("branches")
 								// .value_name("FILE")
-								.help("Prints all branches in the current repository")
+								.help("Prints all local branches in the current repository")
+								.takes_value(false)
+								.required(false)
+								.multiple(false)
+						   	)
+							.arg(Arg::with_name("REMOTES")
+								.short("R")
+								.long("remotes")
+								// .value_name("FILE")
+								.help("Prints remote branches of the current repository")
 								.takes_value(false)
 								.required(false)
 								.multiple(false)
@@ -205,14 +214,20 @@ fn main() {
 	
 	// show branches
 	if matches.is_present("BRANCHES") {
-		branch::get_branch_names();
+		branch::get_branch_names(branch::BranchListings::Local);
 	}
 	
+	// show the current repository
 	if matches.is_present("REPO") {
 		let current_repo = repo::current_repository();
 		if !current_repo.is_none() {
 			println!("{}", current_repo.unwrap());
 		}
+	}
+	
+	// show remote branches
+	if matches.is_present("REMOTES") {
+		branch::get_branch_names(branch::BranchListings::Remotes);
 	}
 	
 	// show commit count


### PR DESCRIPTION
Bundle `git branch --remotes` into this command line tool to allow displaying of remote branches (in this package, using the `-R` flag)