### PR TITLE
Use clap `Derive` for cleaner command line interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33.3"
-json = "0.12.4"
-regex = "1.5.4"
+chrono = "0.4.22"
+clap = { version = "4.0.19", features = ["help", "usage", "error-context", "wrap_help", "cargo"] }
 colored = "2.0.0"
-chrono = "0.4.19"
-hyperpolyglot = "0.1.7"
 colorsys = "0.6.6"
+hyperpolyglot = "0.1.7"
+json = "0.12.4"
+regex = "1.7.0"
 tabular = "0.2.0"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.22"
-clap = { version = "4.0.19", features = ["help", "usage", "error-context", "wrap_help", "cargo"] }
+clap = { version = "4.0.19", features = ["cargo", "wrap_help", "derive"] }
 colored = "2.0.0"
 colorsys = "0.6.6"
 hyperpolyglot = "0.1.7"

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -6,17 +6,20 @@ use tabular::{Table, row};
 
 // Types
 
+#[derive(Clone)]
 pub struct GitContributor {
 	id: GitIdentity,
 	commits: usize,
 	file_contributions: Vec<GitFileContribution>,
 }
 
+#[derive(Clone)]
 struct GitIdentity {
 	email: String,
 	author_names: Vec<String>,
 }
 
+#[derive(Clone)]
 struct GitFileContribution {
 	lines_added: usize,
 	lines_deleted: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,12 @@ mod repo;
 mod status;
 
 extern crate clap;
-use clap::{Arg, Command, crate_version};
+use clap::{
+	ArgAction,
+	crate_version,
+	Parser,
+	value_parser,
+};
 
 // needed for log.rs
 extern crate colored;
@@ -22,141 +27,164 @@ extern crate chrono;
 // -f | --filtered-issues	Prints filtered issues by tag.  By default, prints issues tagged with "enhancement" unless stated otherwise.
 // -e | --exclude-issues	Prints issues excluding issues that are tagged with "depricated" and "pdfsearch" unless stated otherwise.
 // Also, I have notes on github-linguist which I could add to this app, maybe under a `help` subcommand?
+// Also consider using argument groups for things like contrib stats, status, commt counts, etc.
+
+#[derive(Parser)]
+#[command(
+	name = "gl",
+	author = "Jake·W.·Ireland.·<jakewilliami@icloud.com>",
+	version = crate_version!(),
+	about = "Git log and other personalised git utilities.",
+	long_about = "Git log and other personalised git utilities.  By default (i.e., without any arguments), it will print the last 10 commits nicely.",
+)]
+struct Cli {
+	/// Given a number, will print the last n commits nicely.  By default, the programme will print the last 10 commits
+	#[arg(
+		// TODO: as well as -n, we should also be able to do -10, -100, -3, etc
+		action = ArgAction::Set,
+		num_args = 1,
+		value_parser = value_parser!(usize),
+		value_name = "n commits",
+		default_missing_value = "10",
+	)]
+	log_number: Option<usize>,
+
+	/// Prints language breakdown in present repository.  Will print only top n languages if given value (optional).  Defaults to displaying all languages (you can also specify n = 0 for this behaviour)
+	#[arg(
+		short = 'l',
+		long = "languages",
+		action = ArgAction::Set,
+		num_args = 0..=1,
+		value_parser = value_parser!(usize),
+		value_name = "n languages",
+		default_missing_value = "0",  // TODO: consider making this an isize, and using allow_negative_numbers
+	)]
+	languages: Option<usize>,
+
+	/// Prints current git status minimally.  Defaults to the current directory, but you can specify a directory
+	#[arg(
+		short = 's',
+		long = "status",
+		action = ArgAction::Set,
+		num_args = 0..=1,
+		value_name = "dir",
+		default_missing_value = "",
+	)]
+	status: Option<String>,
+
+	/// Gets git status for any dirty repositories, defined from file (WIP)
+	#[arg(
+		short = 'g',
+		long = "global",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	global_status: Option<bool>,
+
+	/// Prints the current branch name
+	#[arg(
+		short = 'b',
+		long = "branch",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	branch: Option<bool>,
+
+	/// Prints all local branches in the current repository
+	#[arg(
+		short = 'B',
+		long = "branches",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	local_branches: Option<bool>,
+
+	/// Print all remote branches of the current repository
+	#[arg(
+		short = 'R',
+		long = "remotes",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	remote_branches: Option<bool>,
+
+	/// Prints the name of the current repository
+	#[arg(
+		short = 'r',
+		long = "repo",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	repo_name: Option<bool>,
+
+	/// Counts the current number of commits on working branch on the current day
+	#[arg(
+		short = 'c',
+		long = "commit-count",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+		conflicts_with = "commit_count_when",
+	)]
+	commit_count: Option<bool>,
+
+	/// Counts the number of commits for a specified day.  Takes value "today" (see also -c), "yesterday", or some number of days ago
+	#[arg(
+		// TODO:
+		//   If you give it 2 numbers, it will show the number of commits since the first number but before the second number (days ago).
+		//   E.g., given 5, 2, it will get the number of commits since 5 days ago, but before 2 days ago.  Given 5 and 1, it will get the
+		//   number of commits in the last 5 days ago, no including anything since yesterday.  This can be done by calculating commits_since(5)
+		//   - commits_since(2), etc.  To do this I need to figure out how to use multiple arguments, otherwise I will have to create a separate
+		//   flag
+		short = 'C',
+		long = "commit-count-when",  // TODO: rename to "commit_count_at"; will need to update minor version (breaking change)
+		action = ArgAction::Set,
+		num_args = 1,
+		value_name = "relative day quantifier",
+		conflicts_with = "commit_count",
+	)]
+	commit_count_when: Option<String>,
+
+	/// Displays the number of commits per author
+	#[arg(
+		short = 'A',
+		long = "author-commit-counts",  // TODO: rename to commit-count-authors; will need to update minor version (breaking change)
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	author_commit_counts: Option<bool>,
+
+	/// Displays some contribution statistics given an author
+	#[arg(
+		short = 'S',
+		long = "author-contrib-stats",
+		action = ArgAction::SetTrue,
+		num_args = 0,
+	)]
+	author_contrib_stats: Option<bool>,
+}
 
 fn main() {
-	let matches = Command::new("gl")
-                            .version(crate_version!())
-                            .author("Jake W. Ireland. <jakewilliami@icloud.com>")
-                            .about("Git log and other personalised git utilities.  By default (i.e., without any arguments), it will print the last 10 commits nicely.")
-							.arg(Arg::new("LOGNUMBER")
-								// TODO: as well as -n we should also be able to do -10, -100, -3, etc
-								// .short("n")
-								// .long("number")
-								// .value_name("FILE")
-								.help("Given a number, will print the last n commits nicely.")
-								// .index(1)
-								// .default_value("10")
-								.num_args(1)
-								.required(false)
-						   	)
-							.arg(Arg::new("LANGUAGES")
-								.short('l')
-								.long("languages")
-								.help("Prints language breakdown in present repository.  Will print only top n languages if given value (optional).")
-								.num_args(0..=1)
-								.required(false)
-						   	)
-							.arg(Arg::new("STATUS")
-								.short('s')
-								.long("status")
-								.help("Prints current git status minimally.")
-								.num_args(0..=1)
-								.required(false)
-						   	)
-							.arg(Arg::new("GLOBAL")
-								.short('g')
-								.long("global")
-								.help("Gets git status for any dirty repositories, defined from file")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("BRANCH")
-								.short('b')
-								.long("branch")
-								.help("Prints the current branch name")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("BRANCHES")
-								.short('B')
-								.long("branches")
-								.help("Prints all local branches in the current repository")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("REMOTES")
-								.short('R')
-								.long("remotes")
-								.help("Prints remote branches of the current repository")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("REPO")
-								.short('r')
-								.long("repo")
-								.help("Prints the name of the current repository")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("COMMITCOUNT")
-								.short('c')
-								.long("commit-count")
-								.help("Counts the current number of commits on working branch on the current day")
-								.required(false)
-								.conflicts_with("COMMITCOUNTWHEN")
-						   	)
-							.arg(Arg::new("COMMITCOUNTWHEN")
-								.short('C')
-								.long("commit-count-when")
-								.help("Counts the number of commits for a specified day.  Takes values \"today\" (see -c), \"yesterday\", or some number of days ago.")
-								// TODO:
-								//   If you give it 2 numbers, it will show the number of commits since the first number but before the second number (days ago).
-                                //   E.g., given 5, 2, it will get the number of commits since 5 days ago, but before 2 days ago.  Given 5 and 1, it will get the
-								//   number of commits in the last 5 days ago, no including anything since yesterday.  This can be done by calculating commits_since(5)
-								//   - commits_since(2), etc.  To do this I need to figure out how to use multiple arguments, otherwise I will have to create a separate
-                                //   flag
-								.num_args(1)
-								.required(false)
-								// .multiple_values(true)
-								.conflicts_with("COMMITCOUNT")
-						   	)
-							.arg(Arg::new("AUTHORCOMMITCOUNTS")
-								.short('A')
-								.long("author-commit-counts")
-								.help("Prints the number of commits per author")
-								.num_args(0)
-								.required(false)
-						   	)
-							.arg(Arg::new("AUTHORCONTRIBSTATS")
-								.short('S')
-								.long("author-contrib-stats")
-								.help("Prints some contribution statistics given an author")
-								.num_args(0)
-								.required(false)
-						   	)
-							.get_matches();
+	let cli = Cli::parse();
 
-
-	// show the git log
-	if !matches.args_present() {
-		let n: usize = 10;
+	if let Some(n) = cli.log_number {
 		log::get_git_log(n);
-		return;
-	}
-	if matches.get_flag("LOGNUMBER") {
-		let n = matches.get_one::<usize>("LOGNUMBER")
-			.unwrap_or(&0);
-		if n != &0 {
-			log::get_git_log(*n);
-		}
 	}
 
 	// show languages
-	if matches.get_flag("LANGUAGES") {
+	if let Some(n) = cli.languages {
 		// This parses _and_ prints the language output
 		// languages::parse_language_data();
 		let language_summary = languages::construct_language_summary();
-		let top_n = matches.get_one::<usize>("LANGUAGES")
-			.map(|n| n.to_owned())
-			.unwrap_or(language_summary.len());
+		let top_n = if n == 0 {
+			language_summary.len()
+		} else {
+			n
+		};
 		languages::print_language_summary(top_n, language_summary);
 	};
 
 	// show status of git repo
-	if matches.get_flag("STATUS") {
-		let dir = matches.get_one::<String>("STATUS")
-			.map(|n| n.to_string())
-			.unwrap_or_else(|| "".to_string());
+	if let Some(dir) = cli.status {
 		let maybe_dir = if dir.is_empty() {
 			None
 		} else {
@@ -166,57 +194,75 @@ fn main() {
 	};
 
 	// show statuses of predefined git repos
-	if matches.get_flag("GLOBAL") {
-		status::global_status();
+	if let Some(global_status) = cli.global_status {
+		if global_status {
+			status::global_status();
+		}
 	};
 
 	// show branch name
-	if matches.get_flag("BRANCH") {
-		let current_branch = branch::current_branch();
-		if current_branch.is_some() {
-			println!("{}", current_branch.unwrap());
+	if let Some(show_branch) = cli.branch {
+		if show_branch{
+			let current_branch = branch::current_branch();
+			if let Some(current_branch) = current_branch {
+				println!("{}", current_branch);
+			}
 		}
 	}
 
 	// show branches
-	if matches.get_flag("BRANCHES") {
-		branch::get_branch_names(branch::BranchListings::Local);
-	}
-
-	// show the current repository
-	if matches.get_flag("REPO") {
-		let current_repo = repo::current_repository();
-		if current_repo.is_some() {
-			println!("{}", current_repo.unwrap());
+	if let Some(show_local_branches) = cli.local_branches {
+		if show_local_branches {
+			branch::get_branch_names(branch::BranchListings::Local);
 		}
 	}
 
 	// show remote branches
-	if matches.get_flag("REMOTES") {
-		branch::get_branch_names(branch::BranchListings::Remotes);
+	if let Some(show_remote_branches) = cli.remote_branches {
+		if show_remote_branches {
+			branch::get_branch_names(branch::BranchListings::Remotes);
+		}
+	}
+
+	// show the current repository
+	if let Some(show_repo_name) = cli.repo_name {
+		if show_repo_name {
+			let current_repo = repo::current_repository();
+			if let Some(current_repo) = current_repo {
+				println!("{}", current_repo);
+			}
+		}
 	}
 
 	// show commit count
-	if matches.get_flag("COMMITCOUNT") {
-		commitcount::get_commit_count("today");
+	if let Some(show_commit_count) = cli.commit_count {
+		if show_commit_count {
+			commitcount::get_commit_count("today");
+		}
 	}
 
-	if matches.get_flag("COMMITCOUNTWHEN") {
-		let input_raw = matches.get_one::<&str>("COMMITCOUNTWHEN");
-
-		let input = input_raw.unwrap();
-		commitcount::get_commit_count(input);
+	if let Some(commit_count_when) = cli.commit_count_when {
+		commitcount::get_commit_count(&commit_count_when);
 	}
 
-	// show number of commits per author, sorted by commit
-	if matches.get_flag("AUTHORCOMMITCOUNTS") {
-		let contributors = contributions::git_contributor_stats();
-		contributions::display_git_author_frequency(contributors);
-	}
+	// Calculate contribution stats
+	let show_author_commit_counts = cli.author_commit_counts.unwrap_or(false);
+	let show_author_contrib_stats = cli.author_contrib_stats.unwrap_or(false);
+	let contributors = if show_author_commit_counts || show_author_contrib_stats {
+		Some(contributions::git_contributor_stats())
+	} else {
+		None
+	};
 
-	// show contribution stats per author, sorted by lines added + deleted
-	if matches.get_flag("AUTHORCONTRIBSTATS") {
-		let contributors = contributions::git_contributor_stats();
-		contributions::display_git_contributions_per_author(contributors);
+	if let Some(contributors) = contributors {
+		// show number of commits per author, sorted by commit
+		if show_author_commit_counts {
+			contributions::display_git_author_frequency(contributors.clone());
+		}
+
+		// show contribution stats per author, sorted by lines added + deleted
+		if show_author_contrib_stats {
+			contributions::display_git_contributions_per_author(contributors.clone());
+		}
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod repo;
 mod status;
 
 extern crate clap;
-use clap::{Arg, App, value_t, crate_version};
+use clap::{Arg, Command, crate_version};
 
 // needed for log.rs
 extern crate colored;
@@ -24,11 +24,11 @@ extern crate chrono;
 // Also, I have notes on github-linguist which I could add to this app, maybe under a `help` subcommand?
 
 fn main() {
-	let matches = App::new("gl")
+	let matches = Command::new("gl")
                             .version(crate_version!())
                             .author("Jake W. Ireland. <jakewilliami@icloud.com>")
                             .about("Git log and other personalised git utilities.  By default (i.e., without any arguments), it will print the last 10 commits nicely.")
-							.arg(Arg::with_name("LOGNUMBER")
+							.arg(Arg::new("LOGNUMBER")
 								// TODO: as well as -n we should also be able to do -10, -100, -3, etc
 								// .short("n")
 								// .long("number")
@@ -36,78 +36,67 @@ fn main() {
 								.help("Given a number, will print the last n commits nicely.")
 								// .index(1)
 								// .default_value("10")
-								.takes_value(true)
+								.num_args(1)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("LANGUAGES")
-								.short("l")
+							.arg(Arg::new("LANGUAGES")
+								.short('l')
 								.long("languages")
 								.help("Prints language breakdown in present repository.  Will print only top n languages if given value (optional).")
-								.takes_value(true)
-						        .min_values(0)
+								.num_args(0..=1)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("STATUS")
-								.short("s")
+							.arg(Arg::new("STATUS")
+								.short('s')
 								.long("status")
 								.help("Prints current git status minimally.")
-								.takes_value(true)
-								.min_values(0)
+								.num_args(0..=1)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("GLOBAL")
-								.short("g")
+							.arg(Arg::new("GLOBAL")
+								.short('g')
 								.long("global")
 								.help("Gets git status for any dirty repositories, defined from file")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("BRANCH")
-								.short("b")
+							.arg(Arg::new("BRANCH")
+								.short('b')
 								.long("branch")
 								.help("Prints the current branch name")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("BRANCHES")
-								.short("B")
+							.arg(Arg::new("BRANCHES")
+								.short('B')
 								.long("branches")
 								.help("Prints all local branches in the current repository")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("REMOTES")
-								.short("R")
+							.arg(Arg::new("REMOTES")
+								.short('R')
 								.long("remotes")
 								.help("Prints remote branches of the current repository")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("REPO")
-								.short("r")
+							.arg(Arg::new("REPO")
+								.short('r')
 								.long("repo")
 								.help("Prints the name of the current repository")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("COMMITCOUNT")
-								.short("c")
+							.arg(Arg::new("COMMITCOUNT")
+								.short('c')
 								.long("commit-count")
 								.help("Counts the current number of commits on working branch on the current day")
 								.required(false)
-								.multiple(false)
 								.conflicts_with("COMMITCOUNTWHEN")
 						   	)
-							.arg(Arg::with_name("COMMITCOUNTWHEN")
-								.short("C")
+							.arg(Arg::new("COMMITCOUNTWHEN")
+								.short('C')
 								.long("commit-count-when")
 								.help("Counts the number of commits for a specified day.  Takes values \"today\" (see -c), \"yesterday\", or some number of days ago.")
 								// TODO:
@@ -116,58 +105,58 @@ fn main() {
 								//   number of commits in the last 5 days ago, no including anything since yesterday.  This can be done by calculating commits_since(5)
 								//   - commits_since(2), etc.  To do this I need to figure out how to use multiple arguments, otherwise I will have to create a separate
                                 //   flag
-								.takes_value(true)
+								.num_args(1)
 								.required(false)
-								// .multiple(true)
+								// .multiple_values(true)
 								.conflicts_with("COMMITCOUNT")
 						   	)
-							.arg(Arg::with_name("AUTHORCOMMITCOUNTS")
-								.short("A")
+							.arg(Arg::new("AUTHORCOMMITCOUNTS")
+								.short('A')
 								.long("author-commit-counts")
 								.help("Prints the number of commits per author")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
-							.arg(Arg::with_name("AUTHORCONTRIBSTATS")
-								.short("S")
+							.arg(Arg::new("AUTHORCONTRIBSTATS")
+								.short('S')
 								.long("author-contrib-stats")
 								.help("Prints some contribution statistics given an author")
-								.takes_value(false)
+								.num_args(0)
 								.required(false)
-								.multiple(false)
 						   	)
 							.get_matches();
 
 
 	// show the git log
-	if matches.args.is_empty() {
+	if !matches.args_present() {
 		let n: usize = 10;
 		log::get_git_log(n);
 		return;
 	}
-	if matches.is_present("LOGNUMBER") {
-		let n = value_t!(matches, "LOGNUMBER", usize)
-			.unwrap_or(0);
-		if n != 0 {
-			log::get_git_log(n);
+	if matches.get_flag("LOGNUMBER") {
+		let n = matches.get_one::<usize>("LOGNUMBER")
+			.unwrap_or(&0);
+		if n != &0 {
+			log::get_git_log(*n);
 		}
 	}
 
 	// show languages
-	if matches.is_present("LANGUAGES") {
+	if matches.get_flag("LANGUAGES") {
 		// This parses _and_ prints the language output
 		// languages::parse_language_data();
 		let language_summary = languages::construct_language_summary();
-		let top_n = value_t!(matches, "LANGUAGES", usize)
+		let top_n = matches.get_one::<usize>("LANGUAGES")
+			.map(|n| n.to_owned())
 			.unwrap_or(language_summary.len());
 		languages::print_language_summary(top_n, language_summary);
 	};
 
 	// show status of git repo
-	if matches.is_present("STATUS") {
-		let dir = value_t!(matches, "STATUS", String)
-			.unwrap_or_else(|_| "".to_string());
+	if matches.get_flag("STATUS") {
+		let dir = matches.get_one::<String>("STATUS")
+			.map(|n| n.to_string())
+			.unwrap_or_else(|| "".to_string());
 		let maybe_dir = if dir.is_empty() {
 			None
 		} else {
@@ -177,12 +166,12 @@ fn main() {
 	};
 
 	// show statuses of predefined git repos
-	if matches.is_present("GLOBAL") {
+	if matches.get_flag("GLOBAL") {
 		status::global_status();
 	};
 
 	// show branch name
-	if matches.is_present("BRANCH") {
+	if matches.get_flag("BRANCH") {
 		let current_branch = branch::current_branch();
 		if current_branch.is_some() {
 			println!("{}", current_branch.unwrap());
@@ -190,12 +179,12 @@ fn main() {
 	}
 
 	// show branches
-	if matches.is_present("BRANCHES") {
+	if matches.get_flag("BRANCHES") {
 		branch::get_branch_names(branch::BranchListings::Local);
 	}
 
 	// show the current repository
-	if matches.is_present("REPO") {
+	if matches.get_flag("REPO") {
 		let current_repo = repo::current_repository();
 		if current_repo.is_some() {
 			println!("{}", current_repo.unwrap());
@@ -203,28 +192,30 @@ fn main() {
 	}
 
 	// show remote branches
-	if matches.is_present("REMOTES") {
+	if matches.get_flag("REMOTES") {
 		branch::get_branch_names(branch::BranchListings::Remotes);
 	}
 
 	// show commit count
-	if matches.is_present("COMMITCOUNT") {
+	if matches.get_flag("COMMITCOUNT") {
 		commitcount::get_commit_count("today");
 	}
 
-	if matches.is_present("COMMITCOUNTWHEN") {
-		let input_raw = matches.value_of("COMMITCOUNTWHEN");
+	if matches.get_flag("COMMITCOUNTWHEN") {
+		let input_raw = matches.get_one::<&str>("COMMITCOUNTWHEN");
 
 		let input = input_raw.unwrap();
 		commitcount::get_commit_count(input);
 	}
 
-	if matches.is_present("AUTHORCOMMITCOUNTS") {
+	// show number of commits per author, sorted by commit
+	if matches.get_flag("AUTHORCOMMITCOUNTS") {
 		let contributors = contributions::git_contributor_stats();
 		contributions::display_git_author_frequency(contributors);
 	}
 
-	if matches.is_present("AUTHORCONTRIBSTATS") {
+	// show contribution stats per author, sorted by lines added + deleted
+	if matches.get_flag("AUTHORCONTRIBSTATS") {
 		let contributors = contributions::git_contributor_stats();
 		contributions::display_git_contributions_per_author(contributors);
 	}


### PR DESCRIPTION
Tasks:
  - [x] Update dependencies (particularly `clap`), which introduces the `Derive` trait [in v3](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#300---2021-12-31)
  - [x] Use `Derive` trait over ~~`App`~~ [`Command`](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#deprecations).