### PR TITLE
Print last 10 logs if no arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl"
-version = "2.2.2"
+version = "2.2.3"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4.22"
-clap = { version = "4.0.19", features = ["cargo", "wrap_help", "derive"] }
+clap = { version = "4.0.22", features = ["cargo", "wrap_help", "derive"] }
 colored = "2.0.0"
 colorsys = "0.6.6"
 hyperpolyglot = "0.1.7"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ pub const ME_IDENTITY: [&str; 4] = [
 	"jakewilliami@icloud.com",
 ];
 
+// Top n results
+pub const DEFAULT_TOP_N_LOG: usize = 10;
+
 // Global
 pub static BASE_DIR: &str = "/Users/jakeireland/projects/";
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod languages;
 mod log;
 mod repo;
 mod status;
+mod config;
 
 extern crate clap;
 use clap::{
@@ -34,18 +35,21 @@ extern crate chrono;
 	name = "gl",
 	author = "Jake·W.·Ireland.·<jakewilliami@icloud.com>",
 	version = crate_version!(),
-	about = "Git log and other personalised git utilities.",
-	long_about = "Git log and other personalised git utilities.  By default (i.e., without any arguments), it will print the last 10 commits nicely.",
 )]
+/// Git log and other personalised git utilities.
+///
+/// By default (i.e., without any arguments), it will print the last 10 commits nicely.
 struct Cli {
-	/// Given a number, will print the last n commits nicely.  By default, the programme will print the last 10 commits
+	/// Given a number, will print the last n commits nicely.
+	///
+	/// By default, the programme will print the last 10 commits
 	#[arg(
 		// TODO: as well as -n, we should also be able to do -10, -100, -3, etc
 		action = ArgAction::Set,
 		num_args = 1,
 		value_parser = value_parser!(usize),
 		value_name = "n commits",
-		default_missing_value = "10",
+		// default_missing_value = "10",
 	)]
 	log_number: Option<usize>,
 
@@ -166,8 +170,13 @@ struct Cli {
 fn main() {
 	let cli = Cli::parse();
 
-	if let Some(n) = cli.log_number {
-		log::get_git_log(n);
+	// Display log
+	if std::env::args().len() <= 1 {
+		log::get_git_log(config::DEFAULT_TOP_N_LOG);
+	} else {
+		if let Some(n) = cli.log_number {
+			log::get_git_log(n);
+		}
 	}
 
 	// show languages


### PR DESCRIPTION
In refactoring to use clap's derive/parser (#12), I made a bug in which running `gl` with no arguments will produce no results.  This MR fixes this bug.