### PR TITLE
Only allow one functional option at a time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "gl"
-version = "2.5.6"
+version = "3.0.0"
 dependencies = [
  "chrono",
  "clap 4.5.20",
@@ -820,9 +820,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.80"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e185e337f816bc8da115b8afcb3324006ccc82eeaddf35113888d3bd8e44ac"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gl"
-version = "2.5.6"
+version = "3.0.0"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 edition = "2018"
 

--- a/src/commit.rs
+++ b/src/commit.rs
@@ -58,7 +58,7 @@ pub fn git_log(n: Option<usize>, opts: Option<&GitLogOptions>) -> Vec<GitCommit>
     };
 
     let re = Regex::new(
-        &format!(r"^(?P<raw>(?P<hash>[a-f0-9]+)\s\-\s(\((?P<meta>[^\)]+)\)\s)?(?P<message>.+)\((?P<daterepr>[^\)]+)\)\s<(?P<author>[^>]*)>){}dateabs\:\s'(?P<dateabs>[^']+)',\shash\:\s'(?P<fullhash>[a-f0-9^']+)',\semail\:\s'(?P<email>[^']*)'$", META_SEP_CHAR.to_string()),
+        &format!(r"^(?P<raw>(?P<hash>[a-f0-9]+)\s\-\s(\((?P<meta>[^\)]+)\)\s)?(?P<message>.+)\((?P<daterepr>[^\)]+)\)\s<(?P<author>[^>]*)>){}dateabs\:\s'(?P<dateabs>[^']+)',\shash\:\s'(?P<fullhash>[a-f0-9^']+)',\semail\:\s'(?P<email>[^']*)'$", *META_SEP_CHAR),
     )
         .unwrap();
 
@@ -126,7 +126,7 @@ fn git_log_str(n: Option<usize>, opts: &GitLogOptions) -> String {
     cmd.arg(format!(
         "--pretty=format:\"{}{}dateabs: '%cd', hash: '%H', email: '%ae'\"",
         log_fmt_str(opts),
-        META_SEP_CHAR.to_string(),
+        *META_SEP_CHAR,
     ));
     if opts.relative {
         // Even though we don't explicitly print the full date when we show the relative commit time, it is useful to have the RFC-2822 date format for parsing in the GitCommit

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,8 +10,5 @@ pub const ME_IDENTITY: [&str; 4] = [
 // Top n results
 pub const DEFAULT_TOP_N_LOG: usize = 10;
 
-// Global
-pub static BASE_DIR: &str = "/Users/jakeireland/projects/";
-
 // Misc
 pub const SHORT_HASH_LENGTH: usize = 7;

--- a/src/contributions.rs
+++ b/src/contributions.rs
@@ -50,7 +50,7 @@ trait ContributorStats {
 
 impl ContributorStats for GitContributor {
     fn commits(&self) -> usize {
-        (&self).contributions.commits.len()
+        self.contributions.commits.len()
     }
 
     fn file_contributions(&self) -> GitFileContributions {

--- a/src/count.rs
+++ b/src/count.rs
@@ -184,7 +184,7 @@ fn commit_count_core(args: Vec<&str>) -> usize {
         }
     } else {
         eprintln!("[ERROR] Failed to get output from `git rev-list`");
-        return 0;
+        0
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,9 +1,7 @@
-use super::config;
 use super::opts::GitLogOptions;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::str;
 
 pub fn get_git_status(dir: &Option<String>, opts: &GitLogOptions) {
     let given_dir: PathBuf = if (dir).is_none() {
@@ -56,66 +54,3 @@ fn git_diff_exit_code(dir: &OsString) {
         .output()
         .expect("Failed to execute `git status`");
 }
-
-pub fn global_status(opts: &GitLogOptions) {
-    let mut input_file: OsString = config::BASE_DIR.into();
-    input_file.push("/scripts/rust/gl/src/global.txt");
-    let input =
-        std::fs::read_to_string(input_file).expect("Something went wrong reading the input file");
-    let v: Vec<&str> = input
-        .split('\n')
-        .filter(|s| !s.is_empty())
-        .filter(|s| s.get(..1).unwrap() != "#")
-        .collect::<Vec<&str>>();
-
-    for r in v {
-        let mut constructed_path: OsString = config::BASE_DIR.into();
-        constructed_path.push("/");
-        constructed_path.push(r);
-        constructed_path.push("/");
-
-        let status = git_status(&constructed_path, opts);
-        let length_of_output: usize = status.split_terminator('\n').count(); // can also use .len()
-
-        if length_of_output == 1_usize {
-            continue;
-        }
-
-        println!("We are looking at {}", constructed_path.to_str().unwrap());
-        println!("{}", status);
-    }
-}
-
-// 25 function parse_git_dirty {
-// 26     status=$(git status 2>&1 | tee)
-// 27     dirty=$(echo -n "${status}" 2> /dev/null | grep "modified:" &> /dev/null; echo "$?")
-// 28     untracked=$(echo -n "${status}" 2> /dev/null | grep "Untracked files" &> /dev/null; echo "$?")
-// 29     ahead=$(echo -n "${status}" 2> /dev/null | grep "Your branch is ahead of" &> /dev/null; echo "$?")
-// 30     newfile=$(echo -n "${status}" 2> /dev/null | grep "new file:" &> /dev/null; echo "$?")
-// 31     renamed=$(echo -n "${status}" 2> /dev/null | grep "renamed:" &> /dev/null; echo "$?")
-// 32     deleted=$(echo -n "${status}" 2> /dev/null | grep "deleted:" &> /dev/null; echo "$?")
-// 33     bits=''
-// 34     if [ "${renamed}" == "0" ]; then
-// 35         bits=">${bits}"
-// 36     fi
-// 37     if [ "${ahead}" == "0" ]; then
-// 38         bits="*${bits}"
-// 39     fi
-// 40     if [ "${newfile}" == "0" ]; then
-// 41         bits="+${bits}"
-// 42     fi
-// 43     if [ "${untracked}" == "0" ]; then
-// 44         bits="?${bits}"
-// 45     fi
-// 46     if [ "${deleted}" == "0" ]; then
-// 47         bits="x${bits}"
-// 48     fi
-// 49     if [ "${dirty}" == "0" ]; then
-// 50         bits="!${bits}"
-// 51     fi
-// 52     if [ ! "${bits}" == "" ]; then
-// 53         echo " ${bits}"
-// 54     else
-// 55         echo ""
-// 56     fi
-// 57 }


### PR DESCRIPTION
The primary change here is using an argument group to collect different arguments (which is then flattened in the primary Cli struct that derives the argument parser).  Importantly, this argument group contains the options that do functional things.  It also specifies `multiple = false`, meaning that we can only run `gl` with one functional option at a time.  (Note that there are still non- functional options that you can use, such as `--rev` and `--all` which will change the way `gl`'s base functionality (pretty logging) will print.)  This change closes #28.

I have considered this a breaking change because you were previously able to run the program with multiple options specified, but this is no longer allowed.

While we are making changes that can be considered breaking changes, we take the opportunity to do a few more outrageous things:
  - Rename `--commit-count-when` to `--commit-count-at`;
  - Deprecate `--global` (as it's not been working for a long time and I don't think I will ever need the functionality);
  - Run clippy on the newest version of the Rust toolchain and perform any suggested changes.  (I really need to get around to adding CI/CD; #30.)

The whole change goes a good way towards addressing #2.